### PR TITLE
Add --writable option to puavo-resolve-api-server to find an API server

### DIFF
--- a/bin/puavo-resolve-api-server
+++ b/bin/puavo-resolve-api-server
@@ -2,7 +2,7 @@
 #
 # ##############################################################################
 #
-# Copyright (C) 2014 Opinsys Oy
+# Copyright (C) 2015 Opinsys Oy
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/bin/puavo-resolve-api-server
+++ b/bin/puavo-resolve-api-server
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 #
 # ##############################################################################
 #
@@ -22,7 +22,7 @@
 
 set -eu
 
-function usage {
+usage () {
     echo "
     usage: $(basename $0) [option]
 
@@ -41,7 +41,8 @@ OPT_WRITABLE=""
 OPT_CLOUD_FALLBACK=""
 
 TEMP=$(getopt -n $PROGRAM_NAME -o wch \
---long writable,cloud-fallback,help)
+--long writable,cloud-fallback,help \
+-- "$@")
 
 eval set -- "$TEMP"
 while true; do

--- a/bin/puavo-resolve-api-server
+++ b/bin/puavo-resolve-api-server
@@ -97,6 +97,8 @@ puavo_apiserver=""
 # Fallback uses API server 
 if [ -s "/etc/puavo/apiserver" ]; then
   puavo_apiserver=$(cat /etc/puavo/apiserver)
+else
+  puavo_apiserver="https://$puavo_domain"
 fi
 
 # Fallback for laptops and wirelessaccesspoints that are not in the school
@@ -105,11 +107,7 @@ if [    "$puavo_hosttype" = "laptop"              \
      -o "$puavo_hosttype" = "wirelessaccesspoint" \
      -o -n "${OPT_CLOUD_FALLBACK}"                \
      -o -n "${OPT_WRITABLE}"                        ]; then
-    if [ -n "${puavo_apiserver}" ]; then
-        echo "https://$puavo_apiserver"
-    else
-        echo "https://$puavo_domain"
-    fi
+    echo "$puavo_apiserver"
     exit 0
 fi
 

--- a/bin/puavo-resolve-api-server
+++ b/bin/puavo-resolve-api-server
@@ -80,11 +80,13 @@ if [ -z "${OPT_WRITABLE}" ]; then
         # dig might not exit with nonzero exit status even if the search fails,
         # instead it will just give an empty response.
         if [ -n "$dig_res" ]; then
-            echo $dig_res | awk '{
-                              sub(/\.$/, "")
-                              printf "https://%s:%s\n", $4, $3
-                            }'
-            exit 0
+            server=$(echo $dig_res | awk '{sub(/\.$/, ""); print $4}')
+            port=$(echo $dig_res | awk '{print $3}')
+
+            if [ "${server%%$puavo_domain}" != "${server}" ]; then
+                echo "https://${server}:${port}"
+                exit 0
+            fi
         fi
     fi
 fi

--- a/bin/puavo-resolve-api-server
+++ b/bin/puavo-resolve-api-server
@@ -20,11 +20,11 @@
 # ##############################################################################
 #
 
-set -eu
+PROGRAM_NAME="$(basename $0)"
 
 usage () {
     echo "
-    usage: $(basename $0) [option]
+    usage: ${PROGRAM_NAME} [option]
 
     Resolve local puavo api server from dns. If the device type is laptop and
     dns resolve fails it will return the public server.
@@ -35,23 +35,18 @@ usage () {
     "
 }
 
-PROGRAM_NAME=puavo-resolve-api-server
-
 OPT_WRITABLE=""
 OPT_CLOUD_FALLBACK=""
 
-TEMP=$(getopt -n $PROGRAM_NAME -o wch \
---long writable,cloud-fallback,help \
--- "$@")
-
-eval set -- "$TEMP"
 while true; do
     case $1 in
         -w|--writable)
-            OPT_WRITABLE=1; shift; continue
+            OPT_WRITABLE=1
+            shift
         ;;
         -c|--cloud-fallback)
-            OPT_CLOUD_FALLBACK=1; shift; continue
+            OPT_CLOUD_FALLBACK=1
+            shift
         ;;
         -h|--help)
             usage
@@ -60,11 +55,17 @@ while true; do
         --)
             break
         ;;
+        "")
+            break
+        ;;
         *)
             printf "Unknown option %s\n" "$1"
+            shift
         ;;
     esac
 done
+
+set -eu
 
 puavo_domain=$(cat /etc/puavo/domain)
 

--- a/bin/puavo-resolve-api-server
+++ b/bin/puavo-resolve-api-server
@@ -60,7 +60,7 @@ while true; do
         ;;
         *)
             printf "Unknown option %s\n" "$1"
-            shift
+            exit 1
         ;;
     esac
 done

--- a/bin/puavo-resolve-api-server
+++ b/bin/puavo-resolve-api-server
@@ -90,6 +90,12 @@ if [ -z "${OPT_WRITABLE}" ]; then
 fi
 
 puavo_hosttype=$(cat /etc/puavo/hosttype)
+puavo_apiserver=""
+
+# Fallback uses API server 
+if [ -s "/etc/puavo/apiserver" ]; then
+  puavo_apiserver=$(cat /etc/puavo/apiserver)
+fi
 
 # Fallback for laptops and wirelessaccesspoints that are not in the school
 # network.
@@ -97,7 +103,11 @@ if [    "$puavo_hosttype" = "laptop"              \
      -o "$puavo_hosttype" = "wirelessaccesspoint" \
      -o -n "${OPT_CLOUD_FALLBACK}"                \
      -o -n "${OPT_WRITABLE}"                        ]; then
-    echo "https://$puavo_domain"
+    if [ -n "${puavo_apiserver}" ]; then
+        echo "https://$puavo_apiserver"
+    else
+        echo "https://$puavo_domain"
+    fi
     exit 0
 fi
 

--- a/bin/puavo-resolve-api-server
+++ b/bin/puavo-resolve-api-server
@@ -1,20 +1,69 @@
-#!/bin/sh
+#!/bin/bash
+#
+# ##############################################################################
+#
+# Copyright (C) 2014 Opinsys Oy
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# ##############################################################################
+#
 
-[ "$1" = "--help" -o "$1" = "-h" ] && {
+set -eu
+
+function usage {
     echo "
     usage: $(basename $0) [option]
 
     Resolve local puavo api server from dns. If the device type is laptop and
     dns resolve fails it will return the public server.
 
+    --writable             Search for writable puavo-rest instance instead of a read-only slave
     --cloud-fallback       Fallback to cloud puavo-rest if bootserver dns lookup fails
 
     "
-} && exit 0
+}
 
-option=$1
+PROGRAM_NAME=puavo-resolve-api-server
 
-set -eu
+OPT_WRITABLE=""
+OPT_CLOUD_FALLBACK=""
+
+TEMP=$(getopt -n $PROGRAM_NAME -o wch \
+--long writable,cloud-fallback,help)
+
+eval set -- "$TEMP"
+while true; do
+    case $1 in
+        -w|--writable)
+            OPT_WRITABLE=1; shift; continue
+        ;;
+        -c|--cloud-fallback)
+            OPT_CLOUD_FALLBACK=1; shift; continue
+        ;;
+        -h|--help)
+            usage
+            exit 0
+        ;;
+        --)
+            break
+        ;;
+        *)
+            printf "Unknown option %s\n" "$1"
+        ;;
+    esac
+done
 
 puavo_domain=$(cat /etc/puavo/domain)
 
@@ -22,15 +71,19 @@ lookup_puavoapi() {
   dig +time=2 +tries=1 SRV _puavo-api._tcp.${puavo_domain} +search +short
 }
 
-if dig_res=$(lookup_puavoapi); then
-    # dig might not exit with nonzero exit status even if the search fails,
-    # instead it will just give an empty response.
-    if [ -n "$dig_res" ]; then
-        echo $dig_res | awk '{
-                          sub(/\.$/, "")
-                          printf "https://%s:%s\n", $4, $3
-                        }'
-        exit 0
+# At the moment only the cloud API server is writable, so we skip the 
+# query and just fallback to cloud server if write access is requested.
+if [ -z "${OPT_WRITABLE}" ]; then
+    if dig_res=$(lookup_puavoapi); then
+        # dig might not exit with nonzero exit status even if the search fails,
+        # instead it will just give an empty response.
+        if [ -n "$dig_res" ]; then
+            echo $dig_res | awk '{
+                              sub(/\.$/, "")
+                              printf "https://%s:%s\n", $4, $3
+                            }'
+            exit 0
+        fi
     fi
 fi
 
@@ -40,7 +93,8 @@ puavo_hosttype=$(cat /etc/puavo/hosttype)
 # network.
 if [    "$puavo_hosttype" = "laptop"              \
      -o "$puavo_hosttype" = "wirelessaccesspoint" \
-     -o "$option"         = "--cloud-fallback" ]; then
+     -o -n "${OPT_CLOUD_FALLBACK}"                \
+     -o -n "${OPT_WRITABLE}"                        ]; then
     echo "https://$puavo_domain"
     exit 0
 fi


### PR DESCRIPTION
that supports writing. In the future there may be also proxying puavo-rest
slaves that support writing, but this version does not try to predict
future too far, so it just returns the cloud server address when
a writable server is requested.